### PR TITLE
Adjust exam and result page display and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1135,6 +1135,10 @@
             transform: scale(0.9);
         }
 
+        #more-menu-icon.active {
+            color: var(--primary-color);
+        }
+
         #more-menu-dropdown {
             display: none;
             position: absolute;
@@ -2032,6 +2036,17 @@
             }
         }
 
+        // Function to toggle more menu
+        function toggleMoreMenu() {
+            const dropdown = document.getElementById('more-menu-dropdown');
+            const moreMenuIcon = document.getElementById('more-menu-icon');
+            
+            if (dropdown && moreMenuIcon) {
+                dropdown.classList.toggle('active');
+                moreMenuIcon.classList.toggle('active');
+            }
+        }
+
         // New function to handle the click behavior of points display
         function updatePointsDisplayClickHandler() {
             const pointsDisplay = document.getElementById('points-display');
@@ -2120,28 +2135,9 @@
         }
 
 
-        // Event listeners for header bar
-        document.getElementById('more-menu-icon').addEventListener('click', (event) => {
-            event.stopPropagation();
-            toggleMoreMenu();
-        });
 
-        document.addEventListener('click', (event) => {
-            const dropdown = document.getElementById('more-menu-dropdown');
-            const moreMenuIcon = document.getElementById('more-menu-icon');
-            if (!dropdown.contains(event.target) && !moreMenuIcon.contains(event.target)) {
-                dropdown.classList.remove('active');
-            }
-        });
 
-        document.getElementById('back-arrow').addEventListener('click', () => {
-            // If currently in exam-taking section, go back to exams list
-            if (document.getElementById('exam-taking-section').classList.contains('active')) {
-                showTab('exams');
-            } else {
-                showTab('home');
-            }
-        });
+
 
         // Swipe functionality for subject content area
         let startX = 0;
@@ -2150,6 +2146,37 @@
 
         document.addEventListener('DOMContentLoaded', () => {
             showTab('home'); // Show home tab by default
+
+            // Event listeners for header bar
+            const moreMenuIcon = document.getElementById('more-menu-icon');
+            const dropdown = document.getElementById('more-menu-dropdown');
+            
+            if (moreMenuIcon) {
+                moreMenuIcon.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                    toggleMoreMenu();
+                });
+            }
+
+            document.addEventListener('click', (event) => {
+                if (dropdown && moreMenuIcon && !dropdown.contains(event.target) && !moreMenuIcon.contains(event.target)) {
+                    dropdown.classList.remove('active');
+                    moreMenuIcon.classList.remove('active');
+                }
+            });
+
+            // Back arrow event listener
+            const backArrow = document.getElementById('back-arrow');
+            if (backArrow) {
+                backArrow.addEventListener('click', () => {
+                    // If currently in exam-taking section, go back to exams list
+                    if (document.getElementById('exam-taking-section').classList.contains('active')) {
+                        showTab('exams');
+                    } else {
+                        showTab('home');
+                    }
+                });
+            }
 
             const darkModeToggle = document.getElementById('dark-mode-toggle');
             const isDarkMode = localStorage.getItem('darkMode') === 'enabled';

--- a/index.html
+++ b/index.html
@@ -627,20 +627,23 @@
             submitButton.textContent = 'تسليم'; // Reset button text to 'تسليم'
         }
 
-        // Function to handle back button from results page
-        function handleBackFromResults() {
-            if (window.currentUserId) {
-                // User is logged in, go to store
-                showTab('store');
-            } else {
-                // User is not logged in, go to profile
-                showTab('profile');
-            }
-        }
+
 
         function displayExamResults(examData, userAnswers, score, totalQuestions, pointsEarned, percentageScore, submissionType, userId) {
             const questionsDisplayContainer = document.getElementById('questions-display-container');
             questionsDisplayContainer.innerHTML = ''; // Clear existing content
+
+            // Show points display in results page and set its behavior
+            const pointsDisplay = document.getElementById('points-display');
+            if (pointsDisplay) {
+                pointsDisplay.style.display = 'flex';
+                // Set click behavior based on login status
+                if (userId) {
+                    pointsDisplay.onclick = () => showTab('store');
+                } else {
+                    pointsDisplay.onclick = () => showTab('profile');
+                }
+            }
 
             let pointsHtml = '';
             // Removed submissionMessage as requested
@@ -668,11 +671,13 @@
                 <div class="exam-review-container">
                     <h3>مراجعة الامتحان:</h3>
                 </div>
-                <button class="back-to-exams-button" onclick="handleBackFromResults();">العودة</button>
+                <button class="back-to-exams-button" onclick="showTab('exams');">العودة</button>
             `;
 
             // Scroll to the top of the questionsDisplayContainer to show results from the top
             questionsDisplayContainer.scrollTop = 0;
+            // Also scroll the window to top to ensure results are visible from the beginning
+            window.scrollTo(0, 0);
 
             const reviewContainer = questionsDisplayContainer.querySelector('.exam-review-container');
 
@@ -1652,7 +1657,7 @@
         }
 
         body:has(#exam-taking-section.active) #points-display {
-            display: none; /* Hide points on exam page */
+            display: flex; /* Show points on exam page */
         }
 
         body:has(#exam-taking-section.active) #exam-timer {
@@ -1983,6 +1988,7 @@
             if (id === 'exam-taking-section') {
                 backArrow.style.display = 'block';
                 examTimerElement.style.display = 'flex';
+                pointsDisplay.style.display = 'flex'; // Show points on exam page
                 // headerBar.style.justifyContent remains 'space-between' (default)
             } else if (id === 'store') {
                 backArrow.style.display = 'block';

--- a/index.html
+++ b/index.html
@@ -427,6 +427,12 @@
             const submitExamButton = document.getElementById('submit-exam-button');
             // const examResultsElement = document.getElementById('exam-results'); // This element is removed
 
+            // Ensure the page scrolls to the top when starting exam
+            window.scrollTo(0, 0);
+            if (questionsDisplayContainer) {
+                questionsDisplayContainer.scrollTop = 0;
+            }
+
             examTitleElement.textContent = 'جاري تحميل الامتحان...';
             examTimerElement.textContent = '';
             questionsDisplayContainer.innerHTML = '<div class="loading-indicator">جاري تحميل الأسئلة...</div>';
@@ -621,6 +627,17 @@
             submitButton.textContent = 'تسليم'; // Reset button text to 'تسليم'
         }
 
+        // Function to handle back button from results page
+        function handleBackFromResults() {
+            if (window.currentUserId) {
+                // User is logged in, go to store
+                showTab('store');
+            } else {
+                // User is not logged in, go to profile
+                showTab('profile');
+            }
+        }
+
         function displayExamResults(examData, userAnswers, score, totalQuestions, pointsEarned, percentageScore, submissionType, userId) {
             const questionsDisplayContainer = document.getElementById('questions-display-container');
             questionsDisplayContainer.innerHTML = ''; // Clear existing content
@@ -651,7 +668,7 @@
                 <div class="exam-review-container">
                     <h3>مراجعة الامتحان:</h3>
                 </div>
-                <button class="back-to-exams-button" onclick="showTab('exams');">العودة</button>
+                <button class="back-to-exams-button" onclick="handleBackFromResults();">العودة</button>
             `;
 
             // Scroll to the top of the questionsDisplayContainer to show results from the top


### PR DESCRIPTION
Display points counter on exam and results pages with conditional navigation, and ensure exam/results pages scroll to the top.

---

[Open in Web](https://cursor.com/agents?id=bc-d2109cf2-48c8-4a21-bbd0-8c8d99f24e38) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d2109cf2-48c8-4a21-bbd0-8c8d99f24e38) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)